### PR TITLE
Fix server loader and add data selection

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,6 +49,7 @@ python comprehensive_tests.py
 ```bash
 python main.py
 ```
+במהלך ההפעלה יוצג תפריט לבחירת קובץ מתוך תיקיית `Data` או להזנת נתיב לקובץ CSV אחר.
 
 ## הפעלת ממשק Streamlit (אופציונלי)
 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 from src.app_controller import AppController
 from services.file_loader import FileLoader
 
-FILE_PATH = "Data/buy_computer.csv"
 LABEL_COL = "BoughtComputer"
 
 
@@ -10,7 +9,12 @@ def main() -> None:
     loader = FileLoader()
     controller = AppController(LABEL_COL, loader=loader)
 
-    controller.load_and_prepare(FILE_PATH)
+    data_path = FileLoader.select_data_file()
+    if not data_path:
+        print("No valid file selected. Exiting.")
+        return
+
+    controller.load_and_prepare(data_path)
     controller.train_model()
 
     accuracy = controller.get_accuracy()

--- a/server.py
+++ b/server.py
@@ -1,15 +1,23 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-from services.data_loader import DataLoader
+import os
+from services.file_loader import FileLoader
 from src.app_controller import AppController
 
 app = FastAPI()
 
-loader = DataLoader()
+loader = FileLoader()
 controller = AppController(label_col="BoughtComputer", loader=loader)
 
-controller.load_and_prepare("Data/buy_computer.csv")
-controller.train_model()
+DATA_PATH = os.getenv("DATA_PATH") or os.path.join(FileLoader.DEFAULT_DATA_DIR, "buy_computer.csv")
+
+try:
+    controller.load_and_prepare(DATA_PATH)
+    controller.train_model()
+except Exception as exc:  # pylint: disable=broad-except
+    # If the data fails to load, keep the server running but warn the user.
+    print(f"Failed to initialise data from {DATA_PATH}: {exc}")
+    controller = None
 
 class Record(BaseModel):
     record: dict
@@ -17,6 +25,8 @@ class Record(BaseModel):
 
 @app.get("/accuracy")
 def get_accuracy():
+    if controller is None:
+        raise HTTPException(status_code=400, detail="Data not initialised")
     try:
         acc = controller.get_accuracy()
         return {"accuracy": acc}
@@ -25,6 +35,8 @@ def get_accuracy():
 
 @app.get("/schema")
 def get_schema():
+    if controller is None:
+        raise HTTPException(status_code=400, detail="Data not initialised")
     try:
         return controller.get_schema()
     except Exception as e:
@@ -32,6 +44,8 @@ def get_schema():
 
 @app.post("/predict")
 def predict(record: Record):
+    if controller is None:
+        raise HTTPException(status_code=400, detail="Data not initialised")
     try:
         result = controller.predict_record(record.record)
         return {"prediction": result}

--- a/services/data_loader.py
+++ b/services/data_loader.py
@@ -1,10 +1,20 @@
-from abc import ABC,abstractmethod
+"""Base interface for loading data."""
 
-class DataLoader:
+from abc import ABC, abstractmethod
+
+
+class DataLoader(ABC):
+    """Abstract base class for data loaders."""
 
     @abstractmethod
-    def load_data(self,file_path: str):
-        pass
+    def load_data(self, file_path: str):
+        """Load data from ``file_path`` and return it.
+
+        Implementations should raise ``ValueError`` with a helpful message when
+        loading fails so calling code can present a clear error to the user.
+        """
+        raise NotImplementedError
+
 
 
 

--- a/services/file_loader.py
+++ b/services/file_loader.py
@@ -1,20 +1,76 @@
+"""Concrete implementation of ``DataLoader`` for local CSV files."""
+
+import os
 import pandas as pd
 from services.data_loader import DataLoader
 
 class FileLoader(DataLoader):
+    """Load CSV files from disk."""
+
+    DEFAULT_DATA_DIR = "Data"
+
     @staticmethod
-    def load_data(file_path: str) -> pd.DataFrame:
+    def select_data_file(data_dir: str = None) -> str:
+        """Interactively select a data file.
+
+        Parameters
+        ----------
+        data_dir : str, optional
+            Directory to search for CSV files. Defaults to ``FileLoader.DEFAULT_DATA_DIR``.
+
+        Returns
+        -------
+        str
+            The chosen file path or ``None`` if selection failed.
         """
-        Load data from a CSV file into a pandas DataFrame.
-        
-        Args:
-            file_path (str): Path to the CSV file.
-        
-        Returns:
-            pd.DataFrame: Loaded data.
+
+        data_dir = data_dir or FileLoader.DEFAULT_DATA_DIR
+        if not os.path.isdir(data_dir):
+            print(f"Data directory not found: {data_dir}")
+            return None
+
+        csv_files = [f for f in os.listdir(data_dir) if f.endswith(".csv")]
+        if not csv_files:
+            print(f"No CSV files found in {data_dir}")
+            return None
+
+        print("Available data files:")
+        for idx, fname in enumerate(csv_files, start=1):
+            print(f"{idx}. {fname}")
+        print("0. Enter a custom path")
+
+        choice = input("Select file number: ").strip()
+        if choice == "0":
+            return input("Enter full CSV path: ").strip()
+
+        try:
+            idx = int(choice)
+            if 1 <= idx <= len(csv_files):
+                return os.path.join(data_dir, csv_files[idx - 1])
+        except ValueError:
+            pass
+
+        print("Invalid selection.")
+        return None
+
+    def load_data(self, file_path: str) -> pd.DataFrame:
+        """Load a CSV file into a ``DataFrame``.
+
+        Raises a ``ValueError`` if loading fails so the caller can handle the
+        error appropriately.
         """
+
+        if not file_path:
+            raise ValueError("No file path provided")
+
         try:
             data = pd.read_csv(file_path)
-            return data
-        except Exception as e:
-            raise ValueError(f"Error loading data from {file_path}: {e}")
+        except FileNotFoundError:
+            raise ValueError(f"File not found: {file_path}")
+        except Exception as exc:  # pylint: disable=broad-except
+            raise ValueError(f"Error loading data from {file_path}: {exc}") from exc
+
+        if data.empty:
+            raise ValueError(f"Loaded DataFrame from {file_path} is empty")
+
+        return data

--- a/src/app_controller.py
+++ b/src/app_controller.py
@@ -14,10 +14,18 @@ class AppController:
         self.classifier = None
         self.evaluator = None
 
-    def load_and_prepare(self, file_path):
-        self.file_path, self.label_name = DataValidator.validate_cli(file_path, self.label_col)
-        self.data = self.loader.load_data(self.file_path)
-        # print(f"[DEBUG] Loaded data:\n{self.data.head()}")
+    def load_and_prepare(self, file_path: str):
+        """Load the dataset from ``file_path`` and prepare splits."""
+
+        self.file_path, self.label_name = DataValidator.validate_cli(
+            file_path, self.label_col
+        )
+
+        try:
+            self.data = self.loader.load_data(self.file_path)
+        except ValueError as exc:
+            raise ValueError(f"Failed to load data: {exc}") from exc
+
         cleaner = Cleaner(self.data, self.label_name)
         self.X_train, self.X_test, self.y_train, self.y_test = cleaner.split_data()
 


### PR DESCRIPTION
## Summary
- implement abstract DataLoader and enhance FileLoader
- provide interactive data file selection in main
- fix server to use FileLoader and handle missing data
- improve AppController error handling
- document data selection usage

## Testing
- `pytest comprehensive_tests.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687344f73d48832db44f2b1ec05e82c3